### PR TITLE
Fix class variable

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -60,11 +60,6 @@ class Stack:
         return self.data.pop()
 
 
-class Hack:
-    def __repr__(self) -> str:
-        return "\b" * 5 + "x" + "\b" * 5
-
-
 if __name__ == "__main__":
     pi = 3.14
     ultimate_answer = 42
@@ -144,5 +139,3 @@ if __name__ == "__main__":
     stack = Stack()
     stack.push({"dict_key": ndarray})
     dbg(stack)
-
-    dbg(Hack())

--- a/tests/test_dbg.py
+++ b/tests/test_dbg.py
@@ -566,3 +566,60 @@ def test_control_character():
 
     expected_outputs = "Hack() = x"
     _assert_correct(stdout.getvalue(), expected_outputs)
+
+
+def test_empty_class():
+    stdout, _ = _redirect_stdout_stderr_to_buffer()
+
+    class Hack:
+        pass
+
+    dbg(Hack())
+    _reset_stdout_stderr()
+
+    expected_outputs = """
+Hack() = Hack {
+}
+"""
+
+    _assert_correct(stdout.getvalue(), expected_outputs)
+
+
+def test_class_variable():
+    # Thanks for bug report from codycjy, https://github.com/WenqingZong/crab_dbg/issues/18
+    stdout, _ = _redirect_stdout_stderr_to_buffer()
+
+    class Hack:
+        a = 1
+
+    dbg(Hack())
+    _reset_stdout_stderr()
+
+    expected_outputs = """
+Hack() = Hack {
+    Hack.a: 1
+}
+"""
+
+    _assert_correct(stdout.getvalue(), expected_outputs)
+
+
+def test_instance_variable_overloads_class_variable():
+    stdout, _ = _redirect_stdout_stderr_to_buffer()
+
+    class Hack:
+        a = 1
+
+        def __init__(self):
+            self.a = 2
+
+    dbg(Hack())
+    _reset_stdout_stderr()
+
+    expected_outputs = """
+Hack() = Hack {
+    a: 2
+}
+"""
+
+    _assert_correct(stdout.getvalue(), expected_outputs)


### PR DESCRIPTION
Fix #18 

Now it prints:
```text
[<file>:<row>:<col>] Hack() = Hack {
    Hack.a: 1
}
```

Note the preceding class name to indicate this is a class variable.

Also, if an instance variable has the same name as the class variable, then only the instance variable should be printed:
```python3
class Hack:
    a = 1

    def __init__(self):
        self.a = 2
```

`dbg` should only print:
```text
[<file>:<row>:<col>] Hack() = Hack {
    a: 2
}
```